### PR TITLE
Added support for passing raw timestamps to time()

### DIFF
--- a/simpleDSTadjust.cpp
+++ b/simpleDSTadjust.cpp
@@ -17,9 +17,12 @@ simpleDSTadjust::simpleDSTadjust(struct dstRule startRule, struct dstRule endRul
 }
 
 // Public
-time_t simpleDSTadjust::time(char **abbrev)
+time_t simpleDSTadjust::time(char **abbrev, time_t now)
 {
- time_t now = ::time(NULL);  // Call the original time() function
+ if(now == 0)
+ {
+  now = ::time(NULL);  // Call the original time() function
+ }
  uint8_t year = calcYear(now);
  static time_t dstStart;  // Start of DST in specific Year (seconds since 1970)
  static time_t dstEnd;    // End of DST in listed Year (seconds since 1970)

--- a/simpleDSTadjust.h
+++ b/simpleDSTadjust.h
@@ -38,7 +38,7 @@ class simpleDSTadjust {
 
   public:
 	simpleDSTadjust(struct dstRule startRule, struct dstRule endRule );
-	time_t time(char **abbrev);
+	time_t time(char **abbrev, time_t rawTime=0);
 
   private:
 	uint8_t calcYear(time_t time);

--- a/simpleDSTadjust.h
+++ b/simpleDSTadjust.h
@@ -38,7 +38,7 @@ class simpleDSTadjust {
 
   public:
 	simpleDSTadjust(struct dstRule startRule, struct dstRule endRule );
-	time_t time(char **abbrev, time_t rawTime=0);
+	time_t time(char **abbrev, time_t now=0);
 
   private:
 	uint8_t calcYear(time_t time);


### PR DESCRIPTION
In a few projects I've either received timestamps over ESP-NOW, or from onboard RTCs, and can't or won't connect to wifi for NTP. To support that time() needs an option that doesn't rely on the espressif time functions.

The change should be drop in, and shouldn't alter behavior for existing code. 