### PR TITLE
add support for esp32 architecture

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Automatic Daylight Saving Time adjust functionality for Arduino/ESP8266
 paragraph=Universal rule based automatic Daylight Saving Time adjust library that implements DST aware version of the esp8266 time() function.
 category=Timing
 url=https://github.com/neptune2/simpleDSTadjust
-architectures=esp8266
+architectures=esp8266, esp32
 


### PR DESCRIPTION
add the esp32 architecture to the supported platforms in order to avoid the compiler warning